### PR TITLE
Update README.md

### DIFF
--- a/phpserver/README.md
+++ b/phpserver/README.md
@@ -31,7 +31,7 @@ For more informations about the installation process using the CLI, you can cons
 
 ### How to run Magento
 
-Example usage: ```php -S 127.0.0.1:8082 -t ./pub/ ../phpserver/router.php```
+Example usage: ```php -S 127.0.0.1:8082 -t ./pub/ ./phpserver/router.php```
 
 ### What exactly the script does
 


### PR DESCRIPTION
removes extra dot on "How to run Magento"

While following the steps in readme file, I encountered a error (extra dot) in "How to run Magento" section. This PR removes that extra dot.

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
This change reduces the number of errors in documentation/readme files.

### Fixed Issues (if relevant)


### Manual testing scenarios (*)
This only removes an extra dot in php run magento command. I have manually tested on my local machine.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
